### PR TITLE
Add chaos mode fruit effects and minor gameplay fixes

### DIFF
--- a/games/chaos/chaos.html
+++ b/games/chaos/chaos.html
@@ -2,7 +2,7 @@
 <html lang="es">
 <head>
   <meta charset="UTF-8" />
-  <title>Modo Chaos</title>
+  <title>Modo Caos</title>
   <link rel="stylesheet" href="chaos.css" />
   <link rel="icon" href="../../assets/images/icons-snake-64.png" type="image/png" />
 </head>

--- a/games/classic/classic.js
+++ b/games/classic/classic.js
@@ -36,7 +36,7 @@ gameInterval = setInterval(drawGame, gameSpeed);
 function generateRandomPosition() {
   return {
     x: Math.floor(Math.random() * cellCount),
-    y: Math.floor(Math.random() * cellCount)
+    y: Math.floor(Math.random() * (cellCount - 1)) + 1 
   };
 }
 

--- a/games/timer/timer.js
+++ b/games/timer/timer.js
@@ -39,7 +39,7 @@ gameInterval = setInterval(drawGame, gameSpeed);
 function generateRandomPosition() {
   return {
     x: Math.floor(Math.random() * cellCount),
-    y: Math.floor(Math.random() * cellCount)
+    y: Math.floor(Math.random() * (cellCount - 1)) + 1 
   };
 }
 

--- a/main.html
+++ b/main.html
@@ -11,7 +11,7 @@
     <h2>Menú Principal</h2>
     <button onclick="location.href='games/classic/classic.html'">Modo Clásico</button>
     <button onclick="location.href='games/timer/timer.html'">Modo Contrarreloj</button>
-    <button onclick="location.href='games/chaos/chaos.html'">Modo Chaos</button>
+    <button onclick="location.href='games/chaos/chaos.html'">Modo Caos</button>
     <button disabled>Perfil</button>
     <button id="settingsBtn">Ajustes</button>
   </div>


### PR DESCRIPTION
✅ Changes 
🍌 Banana: Temporarily increases game speed.

🍉 Watermelon: Temporarily slows down game speed.

🍇 Grape: Inverts movement controls. Resets when any other fruit is eaten.

🍑 Peach: Activates blackout effect for 2 seconds.

🍏 Apple: Basic score boost.

🧭 Fruit spawn logic updated: Fruits no longer spawn on the first row (score area).